### PR TITLE
Fix rails4 compatibility 

### DIFF
--- a/lib/fix_microsoft_links/railtie.rb
+++ b/lib/fix_microsoft_links/railtie.rb
@@ -1,7 +1,7 @@
 module FixMicrosoftLinks
   class Railtie < Rails::Railtie
     initializer 'fix_microsoft_links.register_middleware' do |app|
-      app.config.middleware.insert_after ::Rack::Lock, FixMicrosoftLinks::Rack::Response
+      app.config.middleware.use FixMicrosoftLinks::Rack::Response
     end
   end
 end


### PR DESCRIPTION
This gem does not work in Rails4 since the Rack::Lock middleware has been removed in rails4.

My suggested fix is to use app.config.middleware.use instead of app.config.middleware.insert_after ::Rack::Lock.
