### PR TITLE
explicit exclusion for additional microsoft outlook user agents

### DIFF
--- a/lib/fix_microsoft_links.rb
+++ b/lib/fix_microsoft_links.rb
@@ -2,20 +2,26 @@ module FixMicrosoftLinks
   module Rack
     class Response
       USER_AGENTS_REGEX = /[^\w](Word|Excel|PowerPoint|ms-office)([^\w]|\z)/
+      EXCLUDE_USER_AGENTS_REGEX = /Microsoft Outlook/
 
-      def initialize(app)  
-        @app = app  
-      end  
+      def initialize(app)
+        @app = app
+      end
 
       def call(env)
         # Clicking a URL from Microsoft apps will redirect you to login to already authenticated sites otherwise :(
         # http://support.microsoft.com/kb/899927
-        if env["HTTP_USER_AGENT"] =~ USER_AGENTS_REGEX
+        if matching_user_agent?(env["HTTP_USER_AGENT"])
           body = StringIO.new("<html><head><meta http-equiv='refresh' content='0'/></head><body></body></html>")
           return [200, {"Content-Type" => "text/html"}, body]
         end
         @app.call(env)
       end
+
+      def matching_user_agent?(user_agent)
+        (user_agent =~ USER_AGENTS_REGEX) && !(user_agent =~ EXCLUDE_USER_AGENTS_REGEX)
+      end
+
     end
   end
 end

--- a/test/regex_test.rb
+++ b/test/regex_test.rb
@@ -4,11 +4,9 @@ require 'fix_microsoft_links'
 
 class RegexTest < Test::Unit::TestCase
 
-  REGEX = FixMicrosoftLinks::Rack::Response::USER_AGENTS_REGEX
-
-
   def test_outook
     assert_no_match "Microsoft Office/14.0 (Windows NT 6.0; Microsoft Outlook 14.0.4760; Pro)"
+    assert_no_match "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; InfoPath.3; Microsoft Outlook 14.0.6131; ms-office; MSOffice 14)"
   end
 
   def test_other_microsoft_apps
@@ -29,12 +27,11 @@ class RegexTest < Test::Unit::TestCase
   private
 
   def assert_match(user_agent)
-    assert user_agent =~ REGEX, "Expected middleware to apply to user agent: #{user_agent}"
+    assert FixMicrosoftLinks::Rack::Response.new(nil).matching_user_agent?(user_agent), "Expected middleware to apply to user agent: #{user_agent}"
   end
 
   def assert_no_match(user_agent)
-    assert !(user_agent =~ REGEX), "Did not expect middleware to apply to user agent: #{user_agent}"
+    assert !FixMicrosoftLinks::Rack::Response.new(nil).matching_user_agent?(user_agent), "Did not expect middleware to apply to user agent: #{user_agent}"
   end
-
 
 end


### PR DESCRIPTION
Explicitly exclude Microsoft Outlook user-agents which happen to also include the 'ms-office' text from matching, to fix e.g. Outlook failing to import rss feeds.  Also,
- add test coverage
- introduce a helper method to facilitate tests without having to duplicate the application logic in the tests
- remove a little bit of extraneous whitespace
