### PR TITLE
Given the similar behavior of LibreOffice and Konqueror it worked out…

### DIFF
--- a/lib/fix_microsoft_links.rb
+++ b/lib/fix_microsoft_links.rb
@@ -1,7 +1,7 @@
 module FixMicrosoftLinks
   module Rack
     class Response
-      USER_AGENTS_REGEX = /[^\w](Word|Excel|PowerPoint|ms-office)([^\w]|\z)/
+      USER_AGENTS_REGEX = /[^\w](Word|Excel|PowerPoint|ms-office|Konqueror)([^\w]|\z)/
       EXCLUDE_USER_AGENTS_REGEX = /Microsoft Outlook/
 
       def initialize(app)


### PR DESCRIPTION
… nicely to just add it to the user agents list for me. The offending user agent looks like this: `Mozilla/5.0 (X11; Linux x86_64) KHTML/5.36.0 (like Gecko) Konqueror/5 KIO/5.36`